### PR TITLE
Removed Mekanism warn via lang files

### DIFF
--- a/kubejs/assets/mekanism/lang/en_ud.json
+++ b/kubejs/assets/mekanism/lang/en_ud.json
@@ -1,0 +1,4 @@
+{
+  "constants.mekanism.log_format": "",
+  "constants.mekanism.recipe_warning": ""
+}

--- a/kubejs/assets/mekanism/lang/en_us.json
+++ b/kubejs/assets/mekanism/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "constants.mekanism.log_format": "",
+  "constants.mekanism.recipe_warning": ""
+}


### PR DESCRIPTION
A small change in order to fix #177 in a bit of a hacky way - removing the message completely from the Mekanism lang files (with a resource pack)